### PR TITLE
Detailed messages for tech and user sides 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Additonal options are available in `default.json`
         "discord": {
             "guild_id": 1234567890,                        // Add the Discord Guild ID for the server the bot will be run on
             "enabled_roles": [3456789012, 4567890123],     // Discord Role ID's that you authorise to use the commands.
-            "output_channel": 2345678901                   // A discord channel where output of scheduled jobs will be sent.
+            "tech_channel": 2345678901                     // A discord channel where technical messages of scheduled jobs will be sent.
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",       // RDM front end Endpoint

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Additonal options are available in `default.json`
     "instance": {
         "discord": {
             "guild_id": 1234567890,                        // Add the Discord Guild ID for the server the bot will be run on
-            "output_channel": 2345678901,                  // A discord channel where output of scheduled jobs will be sent.
-            "enabled_roles": [3456789012, 4567890123]      // Discord Role ID's that you authorise to use the commands.
+            "enabled_roles": [3456789012, 4567890123],     // Discord Role ID's that you authorise to use the commands.
+            "output_channel": 2345678901                   // A discord channel where output of scheduled jobs will be sent.
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",       // RDM front end Endpoint

--- a/config.example.json
+++ b/config.example.json
@@ -7,7 +7,7 @@
         "discord": {
             "guild_id": 1234567890,
             "enabled_roles": [3456789012, 4567890123],
-            "output_channel": 2345678901
+            "tech_channel": 2345678901
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",

--- a/config.example.json
+++ b/config.example.json
@@ -6,8 +6,8 @@
     "instance": {
         "discord": {
             "guild_id": 1234567890,
-            "output_channel": 2345678901,
-            "enabled_roles": [3456789012, 4567890123]
+            "enabled_roles": [3456789012, 4567890123],
+            "output_channel": 2345678901
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",

--- a/default.json
+++ b/default.json
@@ -10,7 +10,7 @@
         "discord": {
             "guild_id": 0,
             "enabled_roles": [0, 0],
-            "output_channel": 0,
+            "tech_channel": 0,
             "user_channel": 0
         },
         "rdm": {

--- a/default.json
+++ b/default.json
@@ -9,8 +9,9 @@
     "instance": {
         "discord": {
             "guild_id": 0,
+            "enabled_roles": [0, 0],
             "output_channel": 0,
-            "enabled_roles": [0, 0]
+            "user_channel": 0
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",
@@ -26,5 +27,11 @@
     "sentry": {
         "dns": "",
         "traces_sample_rate": 1.0
+    },
+    "message": {
+        "tech_channel_message_success": "**[Success]** {type} job with action **{action}** for groups **{assignments_groups}**",
+        "tech_channel_message_fail": "**[Fail]** {type} job with action **{action}** for groups **{assignments_groups}**",
+        "user_channel_message_request": "Quests scan has started.",
+        "user_channel_message_start": "IV scans are back."
     }
 }

--- a/rdmass/bot.py
+++ b/rdmass/bot.py
@@ -23,7 +23,9 @@ status_refresh_component = manage_components.create_actionrow(
 @client.event
 async def on_ready() -> None:
     print("RDMAss ready to shine!")
-    scheduler.start()
+
+    if not scheduler.running:
+        scheduler.start()
 
 
 @client.event

--- a/rdmass/bot.py
+++ b/rdmass/bot.py
@@ -34,19 +34,42 @@ async def on_component(ctx: ComponentContext) -> None:
 
 
 @client.event
-async def sched_assignment_group(
-    assignments_groups: List[Text], action: Text, schedule_name: Text = None, output_channel: int = None
-) -> None:
+async def sched_assignment_group(assignments_groups: List[Text], action: Text) -> None:
     success = await handle_assignment_group(assignments_groups, action)
 
-    if output_channel:
+    # handle tech message
+    if config.instance.discord.output_channel:
+        output_channel = await client.fetch_channel(config.instance.discord.output_channel)
+
         output_message = (
-            f"Scheduled job **{schedule_name}** with action **{action}** "
-            f"fired for groups **{', '.join(assignments_groups)}** "
-            f"**{'failed!' if not success else 'was successful.'}**"
+            config.message.tech_channel_message_success if success else config.message.tech_channel_message_fail
+        ).format(
+            **{
+                "action": action,
+                "type": "Scheduled",
+                "assignments_groups": ", ".join(assignments_groups),
+            }
         )
-        channel = await client.fetch_channel(output_channel)
-        await channel.send(output_message)
+
+        await output_channel.send(output_message)
+
+    # handle users message
+    if success and config.instance.discord.user_channel:
+        user_channel = await client.fetch_channel(config.instance.discord.user_channel)
+
+        output_message = (
+            config.message.user_channel_message_request
+            if action == "request"
+            else config.message.user_channel_message_start
+        ).format(
+            **{
+                "action": action,
+                "type": "Scheduled",
+                "assignments_groups": ", ".join(assignments_groups),
+            }
+        )
+
+        await user_channel.send(output_message)
 
 
 @slash.slash(name="rdm-jobs", guild_ids=[config.instance.discord.guild_id], permissions=permissions)
@@ -210,10 +233,15 @@ async def rdm_assignment_group(ctx: ComponentContext) -> Optional[SlashMessage]:
 
     elif action_type_ctx.custom_id == "instant":
         success = await handle_assignment_group(selected_assignments, action)
+
         output_message = (
-            f"Instant job with action **{action_row_ctx.custom_id}** "
-            f"fired for groups **{', '.join(selected_assignments)}** "
-            f"{'**failed!**' if not success else 'was **successful.**'}"
+            config.message.tech_channel_message_success if success else config.message.tech_channel_message_fail
+        ).format(
+            **{
+                "action": action_row_ctx.custom_id,
+                "type": "Instant",
+                "assignments_groups": ", ".join(selected_assignments),
+            }
         )
         return await action_type_ctx.edit_origin(
             content=output_message,
@@ -229,8 +257,6 @@ async def rdm_assignment_group(ctx: ComponentContext) -> Optional[SlashMessage]:
             args=[
                 selected_assignments,
                 action_row_ctx.custom_id,
-                scheduler_name,
-                config.instance.discord.output_channel,
             ],
             name=scheduler_name,
         )

--- a/rdmass/bot.py
+++ b/rdmass/bot.py
@@ -38,8 +38,8 @@ async def sched_assignment_group(assignments_groups: List[Text], action: Text) -
     success = await handle_assignment_group(assignments_groups, action)
 
     # handle tech message
-    if config.instance.discord.output_channel:
-        output_channel = await client.fetch_channel(config.instance.discord.output_channel)
+    if config.instance.discord.tech_channel:
+        tech_channel = await client.fetch_channel(config.instance.discord.tech_channel)
 
         output_message = (
             config.message.tech_channel_message_success if success else config.message.tech_channel_message_fail
@@ -51,7 +51,7 @@ async def sched_assignment_group(assignments_groups: List[Text], action: Text) -
             }
         )
 
-        await output_channel.send(output_message)
+        await tech_channel.send(output_message)
 
     # handle users message
     if success and config.instance.discord.user_channel:


### PR DESCRIPTION
Add detailed messages for tech and user sides.

**BREAKING CHANGES**
- Renamed `output_channel` to `tech_channel` in config.
- All JOBS have to be re-added after a PR is merged.

User channel could be enabled by `user_channel` key.
Messages are configurable in config tree `message`.
Variables `action, type, assignments_groups` are available for all configurable messages:
- tech_channel_message_success
- tech_channel_message_fail
- user_channel_message_request
- user_channel_message_start


Solves https://github.com/Pupitar/RDMAss/issues/6