### PR TITLE
Detailed messages, minutes picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Additonal options are available in `default.json`
         "discord": {
             "guild_id": 1234567890,                        // Add the Discord Guild ID for the server the bot will be run on
             "enabled_roles": [3456789012, 4567890123],     // Discord Role ID's that you authorise to use the commands.
-            "output_channel": 2345678901                   // A discord channel where output of scheduled jobs will be sent.
+            "tech_channel": 2345678901                     // A discord channel where technical messages of scheduled jobs will be sent.
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",       // RDM front end Endpoint

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Additonal options are available in `default.json`
     },
     "locale": {
         "date_format": "YYYY.MM.DD",                       // Date format
-        "time_format": "HH:mm:ss",                         // Time format
+        "time_format": "HH:mm",                            // Time format
         "timezone": "UTC"                                  // Timezone (used for assignement scheduler)
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Additonal options are available in `default.json`
     "instance": {
         "discord": {
             "guild_id": 1234567890,                        // Add the Discord Guild ID for the server the bot will be run on
-            "output_channel": 2345678901,                  // A discord channel where output of scheduled jobs will be sent.
-            "enabled_roles": [3456789012, 4567890123]      // Discord Role ID's that you authorise to use the commands.
+            "enabled_roles": [3456789012, 4567890123],     // Discord Role ID's that you authorise to use the commands.
+            "output_channel": 2345678901                   // A discord channel where output of scheduled jobs will be sent.
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",       // RDM front end Endpoint

--- a/config.example.json
+++ b/config.example.json
@@ -7,7 +7,7 @@
         "discord": {
             "guild_id": 1234567890,
             "enabled_roles": [3456789012, 4567890123],
-            "output_channel": 2345678901
+            "tech_channel": 2345678901
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",

--- a/config.example.json
+++ b/config.example.json
@@ -6,8 +6,8 @@
     "instance": {
         "discord": {
             "guild_id": 1234567890,
-            "output_channel": 2345678901,
-            "enabled_roles": [3456789012, 4567890123]
+            "enabled_roles": [3456789012, 4567890123],
+            "output_channel": 2345678901
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",

--- a/default.json
+++ b/default.json
@@ -10,7 +10,7 @@
         "discord": {
             "guild_id": 0,
             "enabled_roles": [0, 0],
-            "output_channel": 0,
+            "tech_channel": 0,
             "user_channel": 0
         },
         "rdm": {

--- a/default.json
+++ b/default.json
@@ -21,7 +21,7 @@
     },
     "locale": {
         "date_format": "YYYY.MM.DD",
-        "time_format": "HH:mm:ss",
+        "time_format": "HH:mm",
         "timezone": "UTC"
     },
     "sentry": {

--- a/default.json
+++ b/default.json
@@ -9,8 +9,9 @@
     "instance": {
         "discord": {
             "guild_id": 0,
+            "enabled_roles": [0, 0],
             "output_channel": 0,
-            "enabled_roles": [0, 0]
+            "user_channel": 0
         },
         "rdm": {
             "api_endpoint": "http://127.0.0.1:9000",
@@ -26,5 +27,11 @@
     "sentry": {
         "dns": "",
         "traces_sample_rate": 1.0
+    },
+    "message": {
+        "tech_channel_message_success": "**[Success]** {type} job with action **{action}** for groups **{assignments_groups}**",
+        "tech_channel_message_fail": "**[Fail]** {type} job with action **{action}** for groups **{assignments_groups}**",
+        "user_channel_message_request": "Quests scan has started.",
+        "user_channel_message_start": "IV scans are back."
     }
 }

--- a/rdmass/bot.py
+++ b/rdmass/bot.py
@@ -23,7 +23,9 @@ status_refresh_component = manage_components.create_actionrow(
 @client.event
 async def on_ready() -> None:
     print("RDMAss ready to shine!")
-    scheduler.start()
+
+    if not scheduler.running:
+        scheduler.start()
 
 
 @client.event

--- a/rdmass/bot.py
+++ b/rdmass/bot.py
@@ -34,19 +34,42 @@ async def on_component(ctx: ComponentContext) -> None:
 
 
 @client.event
-async def sched_assignment_group(
-    assignments_groups: List[Text], action: Text, schedule_name: Text = None, output_channel: int = None
-) -> None:
+async def sched_assignment_group(assignments_groups: List[Text], action: Text) -> None:
     success = await handle_assignment_group(assignments_groups, action)
 
-    if output_channel:
+    # handle tech message
+    if config.instance.discord.output_channel:
+        output_channel = await client.fetch_channel(config.instance.discord.output_channel)
+
         output_message = (
-            f"Scheduled job **{schedule_name}** with action **{action}** "
-            f"fired for groups **{', '.join(assignments_groups)}** "
-            f"**{'failed!' if not success else 'was successful.'}**"
+            config.message.tech_channel_message_success if success else config.message.tech_channel_message_fail
+        ).format(
+            **{
+                "action": action,
+                "type": "Scheduled",
+                "assignments_groups": ", ".join(assignments_groups),
+            }
         )
-        channel = await client.fetch_channel(output_channel)
-        await channel.send(output_message)
+
+        await output_channel.send(output_message)
+
+    # handle users message
+    if success and config.instance.discord.user_channel:
+        user_channel = await client.fetch_channel(config.instance.discord.user_channel)
+
+        output_message = (
+            config.message.user_channel_message_request
+            if action == "request"
+            else config.message.user_channel_message_start
+        ).format(
+            **{
+                "action": action,
+                "type": "Scheduled",
+                "assignments_groups": ", ".join(assignments_groups),
+            }
+        )
+
+        await user_channel.send(output_message)
 
 
 @slash.slash(name="rdm-jobs", guild_ids=[config.instance.discord.guild_id], permissions=permissions)
@@ -210,10 +233,15 @@ async def rdm_assignment_group(ctx: ComponentContext) -> Optional[SlashMessage]:
 
     elif action_type_ctx.custom_id == "instant":
         success = await handle_assignment_group(selected_assignments, action)
+
         output_message = (
-            f"Instant job with action **{action_row_ctx.custom_id}** "
-            f"fired for groups **{', '.join(selected_assignments)}** "
-            f"{'**failed!**' if not success else 'was **successful.**'}"
+            config.message.tech_channel_message_success if success else config.message.tech_channel_message_fail
+        ).format(
+            **{
+                "action": action_row_ctx.custom_id,
+                "type": "Instant",
+                "assignments_groups": ", ".join(selected_assignments),
+            }
         )
         return await action_type_ctx.edit_origin(
             content=output_message,
@@ -229,8 +257,6 @@ async def rdm_assignment_group(ctx: ComponentContext) -> Optional[SlashMessage]:
             args=[
                 selected_assignments,
                 action_row_ctx.custom_id,
-                scheduler_name,
-                config.instance.discord.output_channel,
             ],
             name=scheduler_name,
         )

--- a/rdmass/bot.py
+++ b/rdmass/bot.py
@@ -10,7 +10,13 @@ from discord_slash.utils import manage_components
 
 from rdmass.config import permissions, config, scheduler
 from rdmass.rdm import RDMSetApi, RDMGetApi
-from rdmass.utils import handle_bot_list, get_status_message, handle_dt_picker, handle_assignment_group
+from rdmass.utils import (
+    handle_bot_list,
+    get_status_message,
+    handle_dt_picker,
+    handle_assignment_group,
+    scheduler_migration,
+)
 
 client = discord.Client(intents=discord.Intents.all())
 slash = SlashCommand(client, sync_commands=True)
@@ -26,6 +32,7 @@ async def on_ready() -> None:
 
     if not scheduler.running:
         scheduler.start()
+        scheduler_migration()
 
 
 @client.event

--- a/rdmass/bot.py
+++ b/rdmass/bot.py
@@ -38,8 +38,8 @@ async def sched_assignment_group(assignments_groups: List[Text], action: Text) -
     success = await handle_assignment_group(assignments_groups, action)
 
     # handle tech message
-    if config.instance.discord.output_channel:
-        output_channel = await client.fetch_channel(config.instance.discord.output_channel)
+    if config.instance.discord.tech_channel:
+        tech_channel = await client.fetch_channel(config.instance.discord.tech_channel)
 
         output_message = (
             config.message.tech_channel_message_success if success else config.message.tech_channel_message_fail
@@ -51,7 +51,7 @@ async def sched_assignment_group(assignments_groups: List[Text], action: Text) -
             }
         )
 
-        await output_channel.send(output_message)
+        await tech_channel.send(output_message)
 
     # handle users message
     if success and config.instance.discord.user_channel:

--- a/rdmass/rdm.py
+++ b/rdmass/rdm.py
@@ -74,7 +74,7 @@ class RDMSetApi:
         params = {
             "assign_device": True,
             "device_name": device_name,
-            "instance_name": instance_name,
+            "instance": instance_name,
         }
 
         output = await set_request(params)
@@ -86,7 +86,7 @@ class RDMSetApi:
         params = {
             "assign_device_group": True,
             "device_group_name": device_group_name,
-            "instance_name": instance_name,
+            "instance": instance_name,
         }
 
         output = await set_request(params)

--- a/rdmass/utils.py
+++ b/rdmass/utils.py
@@ -8,7 +8,7 @@ from discord_slash import ComponentContext
 from discord_slash.utils import manage_components
 from typing import Set, Text, Dict, List, Tuple, Union, cast, Any, Callable, TypeVar
 
-from rdmass.config import config, logging
+from rdmass.config import config, logging, scheduler
 from rdmass.rdm import RDMGetApi, RDMSetApi
 
 log = logging.getLogger(__name__)
@@ -261,3 +261,10 @@ def timeit(func: F) -> F:
         return result
 
     return cast(F, wrapper)
+
+
+# TODO: Auto migrate old Schedules. Remove me after some time
+def scheduler_migration() -> None:
+    for job in scheduler.get_jobs():
+        if len(job.args) > 2:
+            scheduler.modify_job(job_id=job.id, args=job.args[:2])

--- a/rdmass/utils.py
+++ b/rdmass/utils.py
@@ -1,13 +1,19 @@
-from typing import Set, Text, Dict, List, Tuple, Union
+from timeit import default_timer as timer
 
 import arrow
 import httpx
+from datetime import timedelta
 from discord import Client
 from discord_slash import ComponentContext
 from discord_slash.utils import manage_components
+from typing import Set, Text, Dict, List, Tuple, Union, cast, Any, Callable, TypeVar
 
-from rdmass.config import config
+from rdmass.config import config, logging
 from rdmass.rdm import RDMGetApi, RDMSetApi
+
+log = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
 def create_action_list(
@@ -151,6 +157,7 @@ async def get_status_message() -> Text:
 async def handle_dt_picker(client: Client, ctx: ComponentContext) -> Tuple[ComponentContext, arrow.Arrow, arrow.Arrow]:
     dt_now = arrow.now(config.locale.timezone).shift(hours=+1).replace(minute=0, second=0)
 
+    # DAYS
     days = [
         {"label": f"{dt.format(config.locale.date_format)}", "value": f"{dt.year},{dt.month},{dt.day}"}
         for dt in arrow.Arrow.range("day", dt_now, dt_now.shift(days=+23))
@@ -172,6 +179,8 @@ async def handle_dt_picker(client: Client, ctx: ComponentContext) -> Tuple[Compo
     year, month, day = map(int, days_ctx.selected_options[0].split(","))
 
     tmp_dt = dt_now.replace(year=year, month=month, day=day, hour=0)
+
+    # HOURS
     hours_list = (
         arrow.Arrow.range("hour", dt_now, dt_now.shift(hours=+23))
         if days_ctx.selected_options[0] == days[0]["value"]
@@ -198,13 +207,37 @@ async def handle_dt_picker(client: Client, ctx: ComponentContext) -> Tuple[Compo
     await days_ctx.edit_origin(content="Pick an hour", components=[action_row])
 
     hours_ctx = await manage_components.wait_for_component(client, components=action_row)
-
     year, month, day, hour = map(int, hours_ctx.selected_options[0].split(","))
-
     dt_output = arrow.Arrow(year, month, day, hour, tzinfo=config.locale.timezone)
+
+    # MINUTES
+    minutes = [
+        {
+            "label": f"{dt_output.format(config.locale.date_format)} "
+            f"{dt_output.replace(minute=minute).format(config.locale.time_format)}",
+            "value": f"{minute:02d}",
+        }
+        for minute in list(range(0, 60, 5))
+    ]
+
+    action_list = [
+        manage_components.create_select(
+            custom_id="dt_minutes_picker",
+            placeholder="...",
+            min_values=1,
+            max_values=1,
+            options=minutes,
+        )
+    ]
+    action_row = manage_components.create_actionrow(*action_list)
+    await hours_ctx.edit_origin(content="Pick minute", components=[action_row])
+
+    minutes_ctx = await manage_components.wait_for_component(client, components=action_row)
+
+    dt_output = dt_output.replace(minute=int(minutes_ctx.selected_options[0]))
     dt_output_utc = dt_output.to("utc")
 
-    return hours_ctx, dt_output_utc, dt_output
+    return minutes_ctx, dt_output_utc, dt_output
 
 
 async def handle_assignment_group(assignments_groups: Union[Set, List[Text]], action: Text) -> bool:
@@ -217,3 +250,14 @@ async def handle_assignment_group(assignments_groups: Union[Set, List[Text]], ac
         status = False
     finally:
         return status
+
+
+def timeit(func: F) -> F:
+    def wrapper(*args, **kwargs):
+        start = timer()
+        result = func(*args, **kwargs)
+        end = timer()
+        log.debug(f"{func.__name__} took {timedelta(seconds=end-start)}")
+        return result
+
+    return cast(F, wrapper)


### PR DESCRIPTION
**FEATURES**

- Add detailed messages for tech and user sides https://github.com/Pupitar/RDMAss/issues/6
- Use new API arg https://github.com/Pupitar/RDMAss/issues/12
- Ability to select minutes in scheduled starts. 

**BREAKING CHANGES**
- Renamed `output_channel` to `tech_channel` in config.
- ~~All JOBS have to be re-added after a PR is merged.~~ - resvoled

User channel could be enabled by `user_channel` key.
Messages are configurable in config tree `message`.
Variables `action, type, assignments_groups` are available for all configurable messages:
- tech_channel_message_success
- tech_channel_message_fail
- user_channel_message_request
- user_channel_message_start